### PR TITLE
Update GestureManager.ts

### DIFF
--- a/src/neoges/GestureManager.ts
+++ b/src/neoges/GestureManager.ts
@@ -44,7 +44,7 @@ module neoges
                 console.warn("不存在这个实例");
                 return;
             }
-            hc.slice(index,1);
+            hc.splice(index,1);
             neoges.GestureManager.removeEvent(value.target);
             neoges.GestureManager.eventDict[value.target.hashCode] = null;
         }
@@ -106,6 +106,8 @@ module neoges
             if(neoges.GestureManager.showTouchPoint) {
                 neoges.GestureManager.drawTouchPoint();
             }
+            
+            e.stopPropagation();
         }
         /**根据TOUCH ID判断是不是已经存在了这个触碰对象*/
         private static hasTouchEvent(e:egret.TouchEvent):boolean {


### PR DESCRIPTION
currentTouchObject 存放当前发生事件的显示对象。

当有冒泡情况产生时，除非使用 stopPropagation() 阻止冒泡，否则 TOUCH_BEGIN 传递触发下去，currentTouchObject 最终会绑定到stage，造成之后的 move 与 end 对应的 target 错误。

targetA  start  --  move  --  end
                ↓
targetB  start  --  move  --  end
                ↓
stage     start  -->  move  -->  end
# 

添加 stopPropagation 后

targetA  start  --->  move  --->  end
               ✕ (stopPropagation)
targetB  start  --  move  --  end

stage     start  --  move  --  end

若要能灵活的处理冒泡的情况，估计要用数组存放currentTouchObject [ targetA,targetB,stage] 

然后循环派发 ges.onTouch , 配合处理函数中设置标志位来随时中止循环
